### PR TITLE
Not uninstalling device path protocol from device handle

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -94,7 +94,6 @@ pub fn load_image<R: Read + Len>(reader: &mut R) -> Result<LoadedImage> {
     unsafe {
         // Uninstall the load file and device path protocols since our protocol handle is about to go out of scope
         // TODO: how will the device_handle be deallocated?
-        ret_on_err!(((*bs).UninstallProtocolInterface)(device_handle, &EFI_DEVICE_PATH_PROTOCOL_GUID, mem::transmute(image_path.as_ptr())));
         ret_on_err!(((*bs).UninstallProtocolInterface)(device_handle, &EFI_LOAD_FILE_PROTOCOL_GUID, mem::transmute(&loader.proto)));
     }
 


### PR DESCRIPTION
If the device path protocol is uninstalled, the next boot image fails to load an image.