### PR TITLE
UdpSocket was not being reset when dropping

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -735,6 +735,7 @@ impl Drop for Udp4Socket {
     fn drop(&mut self) {
         // TODO: add the code to panic when any of the below calls fail. (Could be difficult) but maybe we can trace something when we do that.
         unsafe {
+            ((*self.protocol).Configure)(self.protocol, ptr::null());
             ((*self.bs).CloseEvent)(self.send_token.Event);
             ((*self.bs).CloseEvent)(self.recv_token.Event);
             ((*self.binding_protocol).DestroyChild)(self.binding_protocol, &mut self.device_handle);


### PR DESCRIPTION
UdpSocket's drop was not calling configure with a null ptr and this was
resulting in other instances of UdpSocket failing the Configure call
inside the bind_and_connect method with a EFI_ACCESS_DENIED error.