### PR TITLE
Add feature to disable global_allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["bindings", "uefi", "efi", "boot-loader", "os-loader"]
 categories = ["api-bindings", "no-std", "os"]
 license = "MIT"
 
+[features]
+default = ["allocator"]
+allocator = []
 
 [dependencies]
 byteorder = { version = "1", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ use ffi::{
 };
 
 use failure::{Context, Fail, Backtrace};
+#[cfg(allocator)]
 use allocator::EfiAllocator;
 pub use console::{Console, stdin, stdout};
 pub use utils::NullTerminatedAsciiStr;
@@ -76,9 +77,9 @@ pub fn image_handle() -> EFI_HANDLE {
     }
 }
 
-
- #[global_allocator]
- static ALLOCATOR: EfiAllocator = EfiAllocator;
+#[cfg(allocator)]
+#[global_allocator]
+static ALLOCATOR: EfiAllocator = EfiAllocator;
 
 
 // TODO: instead of calling them errors we should change the name to status and remove Fail etc. from them.


### PR DESCRIPTION
This gives dependent projects (such as
https://github.com/oreboot/oreboot/blob/master/src/vendorcode/fsp/coffeelake/src/lib.rs#L7)
the ability to import basic efi data types (CHAR8, GUID, ...) while
opting-out of importing a global allocator.